### PR TITLE
Fix for Issue #4

### DIFF
--- a/src/makeDocumentProjection.ts
+++ b/src/makeDocumentProjection.ts
@@ -40,6 +40,7 @@ export default function makeDocumentProjection<T>(handle: DocHandle<T>) {
 		cleanup() {
 			handle.off("change", patch)
 			handle.off("delete", ondelete)
+			cache.delete(handle)
 		},
 	})
 


### PR DESCRIPTION
Fix for Issue #4 .

Fixes a mount, unmount and remount of `makeDocumentProjection` of same doc handle still alive in memory. (Reference count goes from 1, to 0, to 1 again. After which the listeners are missing from `handle`)